### PR TITLE
Add session ID logging to loguru

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,2 @@
 fastapi[standard]~=0.115.0
+loguru~=0.7.3


### PR DESCRIPTION
This adds a preconfigured loguru logger where we have bound the Pipecat Cloud session ID to the logger so that all lines logged with that logger will include the session ID.

Something to note:  the [loguru](https://github.com/Delgan/loguru) API maintains simplicity by normally not requiring that you pass logger objects around.  This breaks that pattern (optionally).

Something I noticed when testing example pipelines is that there is significant usage of loguru in Pipecat already, where we are logging with the default logger.  Logging that uses the default logger won't have the session ID set.  We _could_ go ahead and set it process-wide, on the default logger, but that would break if we ever tried to have a concurrency of more than one session active in a pod at once.

It might be worth thinking about whether we wanted to add a way in Pipecat to configure logging a little bit.  cc: @aconchillo for thinking about this.
