### PR TITLE
one bot file for both dial-in and dial-out

### DIFF
--- a/pipecat-starters/pstn_sip/Dockerfile
+++ b/pipecat-starters/pstn_sip/Dockerfile
@@ -1,0 +1,7 @@
+FROM dailyco/pipecat-base:latest
+
+COPY ./requirements.txt requirements.txt
+
+RUN pip install --no-cache-dir --upgrade -r requirements.txt
+
+COPY ./bot.py bot.py

--- a/pipecat-starters/pstn_sip/README.md
+++ b/pipecat-starters/pstn_sip/README.md
@@ -1,0 +1,172 @@
+# Voice Bot Starter
+
+A Phone-based conversational agent built with Pipecat. 
+Uses Phone numbers purchased on Daily. Additionally, can handle inbound and outbound SIP.
+
+## Features
+
+- Real-time voice conversations powered by:
+  - Deepgram (STT)
+  - OpenAI (LLM)
+  - Cartesia (TTS)
+- Voice activity detection with Silero
+- Support for interruptions
+- Support for SIP and PSTN
+
+## Required API Keys
+- `DAILY_API_KEY` 
+- `OPENAI_API_KEY`
+- `DEEPGRAM_API_KEY`
+- `CARTESIA_API_KEY`
+
+## Configuration
+
+To make and receive calls currently you have to host a server to 
+handle incoming calls. In the coming weeks, incoming calls will be 
+directly handled within Daily and we will expose an endpoint similar 
+to `{service}/start` that will manage this for you.
+
+In the mean time, you will need to pass the custom fields to
+[{service}/start](https://docs.pipecat.daily.co/agents/active-sessions#using-rest) 
+
+For handling PSTN/SIP within this starter image, we recommend sending 
+the following custom values:
+    
+```python
+# Pass the values that you received in the pinless webhook to start
+# The callId and callDomain are specific to the
+# From is the user
+"dialin_settings": {
+    "to": "+14152251493",
+    "from": "+14158483432",
+    "callId": "string",
+    "callDomain": "string"
+}
+
+# Pass the phoneNumber that you want the bot to call
+"dialout_settings": [{
+    "phoneNumber": "+14158483432",
+    "callerId": "uuid of the phone-number on Daily"}]
+
+# Pass the sipUri to make an outbound SIP call
+"dialout_settings": [{"sipUri": "sip:anotheruser@sip.example.com"}]
+```
+
+## Buy a phone number
+
+You can buy a phone number through the Pipecat Cloud Dashboard, navigate to 
+`Settings` and then `Telephony`. And set up the webhook url to receive the incoming call. 
+
+Or purchase the number using Daily's [PhoneNumbers API](https://docs.daily.co/reference/rest-api/phone-numbers).
+
+```bash
+curl --request POST \
+--url https://api.daily.co/v1/domain-dialin-config \
+--header 'Authorization: Bearer $TOKEN' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+	"type": "pinless_dialin",
+	"name_prefix": "Customer1",
+    "phone_number": "+1PURCHASED_NUM",
+	"room_creation_api": "https://example.com/dial",
+    "hold_music_url": "https://example.com/static/ringtone.mp3",
+	"timeout_config": {
+		"message": "No agent is available right now"
+	}
+}'
+```
+The API returns the static SIP URI (`sip_uri`) which can be called from other SIP services
+
+### Dial-in
+
+When you call the Phone Number or the static SIP URI, the call is received on the 
+Daily infrastructure and immediately put on hold. This triggers the webhook to the 
+`room_creation_api`, which calls the `{service}/start` pipecat cloud endpoint with 
+the data from the webhook copied into the `dialin_settings`. 
+
+```bash
+curl --request POST \
+--url https://api.pipecat.daily.co/v1/public/{service}/start \
+--header 'Authorization: Bearer $TOKEN$' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    'createDailyRoom': true, 
+    'dailyRoomProperties': {
+        'enable_dialout': false, 
+        'sip': {'display_name': 'sip-dialin', 'sip_mode': 'dial-in', 'num_endpoints': 1}, 
+        'exp': 1742353314
+    }, 
+    'body': {
+        'dialin_settings': {
+            'from': '+1CALLER', 
+            'to': '+1PURCHASED', 
+            'call_id': 'callid-uuid', 
+            'call_domain': 'domain-uui'
+        }
+    }
+}
+```
+
+When the bot receives this call and `dialin_settings` is present, it passes the contents 
+to the  `DailyTransport`. The call is then automatically forwarded to the bot. 
+In addition, `dialin_settings` contains `to` and `from` fields that can be used to
+lookup who is calling and what number was called.
+
+Since this is a dial-in call, the bot needs to start speaking immediately when the remote
+user joins (when `on_first_participant_joined` fires). 
+
+```python
+ @transport.event_handler("on_first_participant_joined")
+    async def on_first_participant_joined(transport, participant):
+        if dialin_settings:
+            # the bot will start to speak as soon as the call connects
+            await task.queue_frames([context_aggregator.user().get_context_frame()])
+```
+
+### Dial-out
+
+In dialout, the bot needs the number to be called, we use `dialout_setings` (an array
+of obhect) to pass one or more phone numbers to the bot. See the example below. 
+
+```bash
+curl --request POST \
+--url https://api.pipecat.daily.co/v1/public/{service}/start \
+--header 'Authorization: Bearer $TOKEN$' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    'createDailyRoom': true, 
+    'dailyRoomProperties': {
+        'enable_dialout': false, 
+        'sip': {'display_name': 'dialin', 'sip_mode': 'dial-in', 'num_endpoints': 1}, 
+        'exp': 1742353929
+    }, 
+    'body': {
+        'dialout_settings': [{'phoneNumber': '+1TARGET', 'callerId': 'UUID_OF_PURCHASED_NUM'}]
+    }
+}
+```
+
+The bot receives the `dialout_setting` and begins dialing out as soon as the call's 
+`state` moves to `joined`.
+
+```python
+@transport.event_handler("on_call_state_updated")
+async def on_call_state_updated(transport, state):
+    if state == "joined" and dialout_settings:
+        await start_dialout(transport, dialout_settings)
+```
+
+Since this is a dialout, the bot will wait for the remote party (hopefully a human 
+not voicemail) to speak. It will only respond after it is spoken to. In a future
+version, we will have voicemail detection that will be inserted at this point.
+
+```python
+@transport.event_handler("on_dialout_answered")
+    async def on_dialout_answered(transport, data):
+        # the bot will wait for the user to speak before responding
+        await rtvi.set_bot_ready()
+```
+
+## Deployment
+
+See the [top-level README](../README.md) for deployment instructions.

--- a/pipecat-starters/pstn_sip/README.md
+++ b/pipecat-starters/pstn_sip/README.md
@@ -43,7 +43,7 @@ curl --request POST \
 	"type": "pinless_dialin",
 	"name_prefix": "Customer1",
     "phone_number": "+1PURCHASED_NUM",
-	"room_creation_api": "https://example.com/dial",
+	"room_creation_api": "https://example.com/api/dial",
     "hold_music_url": "https://example.com/static/ringtone.mp3",
 	"timeout_config": {
 		"message": "No agent is available right now"
@@ -55,8 +55,8 @@ The API will return a static SIP URI (`sip_uri`) that can be called from other S
 
 ### Handling dial-in webhook (`room_creation_api`)
 
-To make and receive calls currently you have to host a server t 
-handle incoming calls. In the coming weeks, incoming calls will be 
+To make and receive calls currently you have to host a server that 
+handles incoming calls. In the coming weeks, incoming calls will be 
 directly handled within Daily and we will expose an endpoint similar 
 to `{service}/start` that will manage this for you.
 
@@ -67,9 +67,10 @@ For handling PSTN/SIP within this starter image, we recommend sending
 the following custom values:
     
 ```python
-# Pass the values that you received in the pinless webhook to start
-# The callId and callDomain are specific to the
-# From is the user
+# Pass the values that you received in the pinless webhook to {service}/start
+# The callId and callDomain are internal call state and Daily-specific
+# From is the user dialing in
+# To is the purchased phone number that was dialled
 "dialin_settings": {
     "to": "+14152251493",
     "from": "+14158483432",

--- a/pipecat-starters/pstn_sip/bot.py
+++ b/pipecat-starters/pstn_sip/bot.py
@@ -1,0 +1,268 @@
+#
+# Copyright (c) 2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+from openai.types.chat import ChatCompletionToolParam
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import (
+    EndTaskFrame,
+)
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.processors.frameworks.rtvi import RTVIConfig, RTVIObserver, RTVIProcessor
+from pipecat.services.ai_services import LLMService
+from pipecat.services.cartesia import CartesiaTTSService
+from pipecat.services.deepgram import DeepgramSTTService
+from pipecat.services.openai import OpenAILLMService
+from pipecat.transports.services.daily import DailyParams, DailyTransport
+from pipecatcloud.agent import DailySessionArguments
+
+load_dotenv(override=True)
+
+
+# Function call for the bot to terminate the call.
+# Needed in the case of dial-in and dial-out for the bot to hang up
+async def terminate_call(
+    function_name, tool_call_id, args, llm: LLMService, context, result_callback
+):
+    """Function the bot can call to terminate the call upon completion of a voicemail message."""
+    await llm.queue_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
+    await result_callback("Goodbye")
+
+
+async def main(room_url: str, token: str, body: dict):
+    logger.debug("Starting bot in room: {}", room_url, body)
+
+    # dialin_settings are received when a call is triggered to
+    # Daily via pinless_dialin. This can be a phone number on Daily or a
+    # sip interconnect from Twilio or Telnyx.
+    dialin_settings = None
+    dialled_phonenum = None
+    caller_phonenum = None
+    if raw_dialin_settings := body.get("dialin_settings"):
+        # these fields can capitalize the first letter
+        dialled_phonenum = (raw_dialin_settings.get("To") or raw_dialin_settings.get("to"),)
+        caller_phonenum = (raw_dialin_settings.get("From") or raw_dialin_settings.get("from"),)
+        dialin_settings = {
+            # these fields can be received as snake_case or camelCase.
+            "call_id": raw_dialin_settings.get("callId") or raw_dialin_settings.get("call_id"),
+            "call_domain": raw_dialin_settings.get("callDomain")
+            or raw_dialin_settings.get("call_domain"),
+        }
+        logger.debug(
+            f"Dialin settings: To: {dialled_phonenum}, From: {caller_phonenum}, dialin_settings: {dialin_settings}"
+        )
+
+    voicemail_detection = bool(body.get("voicemail_detection"))
+    if voicemail_detection:
+        logger.debug("Voicemail detection enabled")
+
+    dialout_settings = None
+    dialout_settings = body.get("dialout_settings")
+    logger.debug(f"Dialout settings: {dialout_settings}")
+
+    transport = DailyTransport(
+        room_url,
+        token,
+        "Voice AI Bot",
+        DailyParams(
+            api_key=os.getenv("DAILY_API_KEY"),  # needed for dial-in
+            dialin_settings=dialin_settings,
+            audio_out_enabled=True,
+            vad_enabled=True,
+            vad_analyzer=SileroVADAnalyzer(),
+            vad_audio_passthrough=True,
+        ),
+    )
+
+    # Configure your STT, LLM, and TTS services here
+    # Swap out different processors or properties to customize your bot
+    stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
+    llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"), model="gpt-4o")
+    tts = CartesiaTTSService(
+        api_key=os.getenv("CARTESIA_API_KEY"),
+        voice_id="79a125e8-cd45-4c13-8a67-188112f4dd22",
+    )
+
+    # Set up the initial context for the conversation
+    # You can specified initial system and assistant messages here
+    # or register tools for the LLM to use
+    messages = [
+        {
+            "role": "system",
+            "content": """You are Chatbot, a friendly, helpful robot. Your goal is to demonstrate your capabilities in a succinct way. Your output will be converted to audio so don't include special characters in your answers. Respond to what the user said in a creative and helpful way, but keep your responses brief. Start by introducing yourself.
+
+            - If the user no longer needs assistance, say: "Okay, thank you! Have a great day!"
+            -Then call `terminate_call` immediately.""",
+        },
+    ]
+
+    # Registering the terminate_call function as a tool
+    # This is used to terminate the call when the bot is done
+    llm.register_function("terminate_call", terminate_call)
+    tools = [
+        ChatCompletionToolParam(
+            type="function",
+            function={
+                "name": "terminate_call",
+                "description": "Terminate the call",
+            },
+        )
+    ]
+    # tools = NotGiven()
+
+    # This sets up the LLM context by providing messages and tools
+    context = OpenAILLMContext(messages, tools)
+    context_aggregator = llm.create_context_aggregator(context)
+
+    # RTVI events for Pipecat client UI
+    rtvi = RTVIProcessor(config=RTVIConfig(config=[]))
+
+    # A core voice AI pipeline
+    # Add additional processors to customize the bot's behavior
+    pipeline = Pipeline(
+        [
+            transport.input(),
+            rtvi,
+            stt,
+            context_aggregator.user(),
+            llm,
+            tts,
+            transport.output(),
+            context_aggregator.assistant(),
+        ]
+    )
+
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(
+            allow_interruptions=True,
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        observers=[RTVIObserver(rtvi)],
+    )
+
+    # helper function to start dialout
+    # this is called when the call state is updated to "joined"
+    # and set_bot_ready() when dialout answered is fired
+    async def start_dialout(transport, dialout_settings):
+        for dialout_setting in dialout_settings:
+            # Change from attribute access to dictionary access
+            if "phoneNumber" in dialout_setting:
+                logger.info(f"Dialing number: {dialout_setting['phoneNumber']}")
+                if "callerId" in dialout_setting:
+                    logger.info(f"with callerId: {dialout_setting['callerId']}")
+                    await transport.start_dialout(
+                        {
+                            "phoneNumber": dialout_setting["phoneNumber"],
+                            "callerId": dialout_setting["callerId"],
+                        }
+                    )
+                else:
+                    logger.info("with no callerId")
+                    await transport.start_dialout({"phoneNumber": dialout_setting["phoneNumber"]})
+            elif "sipUri" in dialout_setting:
+                logger.info(f"Dialing sipUri: {dialout_setting['sipUri']}")
+                await transport.start_dialout({"sipUri": dialout_setting["sipUri"]})
+
+    # Configure handlers for dialing out
+    # dialout connected fires when the call starts ringing
+    @transport.event_handler("on_dialout_connected")
+    async def on_dialout_connected(transport, data):
+        logger.debug(f"Dial-out connected: {data}")
+
+    # dialout answered fires when the ringing call is off hook
+    @transport.event_handler("on_dialout_answered")
+    async def on_dialout_answered(transport, data):
+        logger.debug(f"Dial-out answered: {data} and set_bot_ready")
+        await rtvi.set_bot_ready()
+
+    @transport.event_handler("on_dialin_ready")
+    async def on_dialin_ready(transport, data):
+        # For Twilio, Telnyx, etc. You need to update the state of the call
+        # and forward it to the sip_uri..
+        logger.debug(f"Dial-in ready: {data}")
+
+    @transport.event_handler("on_dialin_connected")
+    async def on_dialin_connected(transport, data):
+        logger.debug(f"Dial-in connected: {data} and set_bot_ready")
+        await rtvi.set_bot_ready()
+
+    # set bot ready when the rtvi client sends ready.
+    # this is not sent for telephony endpoints
+    @rtvi.event_handler("on_client_ready")
+    async def on_client_ready(rtvi):
+        logger.debug("Client ready sent by remote, set_bot_ready")
+        await rtvi.set_bot_ready()
+
+    # client ready when recording is ready.
+    # For telephony endpoints, reconsider this
+    @transport.event_handler("on_recording_started")
+    async def on_recording_started(transport, status):
+        logger.debugf(f"Recording started: {status} and setting set_bot_ready")
+        await transport.on_recording_started(status)
+        await rtvi.set_bot_ready()
+
+    @transport.event_handler("on_call_state_updated")
+    async def on_call_state_updated(transport, state):
+        logger.info(f"on_call_state_updated, state: {state}")
+        if state == "joined" and dialout_settings:
+            logger.info(f"on_call_state_updated, dialout_settings: {dialout_settings}")
+            await start_dialout(transport, dialout_settings)
+        if state == "left":
+            await task.cancel()
+
+    @transport.event_handler("on_first_participant_joined")
+    async def on_first_participant_joined(transport, participant):
+        logger.info("First participant joined: {}", participant["id"])
+        # Capture the participant's transcription
+        await transport.capture_participant_transcription(participant["id"])
+        # Kick off the conversation
+        if dialin_settings:
+            # For the dialin case, we want the bot to greet the user.
+            # We can prompt the bot to speak by putting the context into the pipeline.
+            await task.queue_frames([context_aggregator.user().get_context_frame()])
+
+    @transport.event_handler("on_joined")
+    async def on_joined(transport, data):
+        session_id = data["meetingSession"]["id"]
+        bot_id = data["participants"]["local"]["id"]
+        logger.info(f"Session ID: {session_id}, Bot ID: {bot_id}")
+
+    @transport.event_handler("on_participant_left")
+    async def on_participant_left(transport, participant, reason):
+        logger.debug(f"Participant left: {participant}, reason: {reason}")
+        await task.cancel()
+
+    runner = PipelineRunner(handle_sigint=False, force_gc=True)
+
+    await runner.run(task)
+
+
+async def bot(args: DailySessionArguments):
+    """Main bot entry point compatible with the FastAPI route handler.
+
+    Args:
+        room_url: The Daily room URL
+        token: The Daily room token
+        body: The configuration object from the request body can contain dialin_settings, dialout_settings, voicemail_detection, and call_transfer
+        session_id: The session ID for logging
+    """
+    logger.info(f"Bot process initialized {args.room_url} {args.token}")
+
+    try:
+        await main(args.room_url, args.token, args.body)
+        logger.info("Bot process completed")
+    except Exception as e:
+        logger.exception(f"Error in bot process: {str(e)}")
+        raise

--- a/pipecat-starters/pstn_sip/requirements.txt
+++ b/pipecat-starters/pstn_sip/requirements.txt
@@ -1,0 +1,3 @@
+pipecat-ai[openai,daily,deepgram,cartesia,silero]
+python-dotenv
+pipecatcloud


### PR DESCRIPTION
This bot file handles both PSTN dial-in, PSTN dial-out, SIP dial-in, and SIP dial-out.

To test you will need to 
1. configure a server: https://github.com/pipecat-ai/pipecat/pull/1418
2. purchase a number via the pcc dashboard and pass the server url to `webhook url`
3. call the number :) or trigger dial-out by passing `dialout_settings` with phoneNumber. (see readme)
