### PR TITLE
Make the base Pipecat image's Python version configurable

### DIFF
--- a/pipecat-base/Dockerfile
+++ b/pipecat-base/Dockerfile
@@ -1,7 +1,9 @@
-FROM python:3.10-slim
+ARG PYTHON_VERSION=3.10
+FROM python:${PYTHON_VERSION}-slim
 WORKDIR /app
 RUN apt update && apt install -y libopenblas-dev libresample1 libresample-dev && apt clean
-RUN ln -s /krisp/python/pipecat_ai_krisp /usr/local/lib/python3.10/site-packages/pipecat_ai_krisp
+RUN SHORT_PYTHON_VERSION=${PYTHON_VERSION%.*} && \
+    ln -s /krisp/python/pipecat_ai_krisp /usr/local/lib/python$SHORT_PYTHON_VERSION/site-packages/pipecat_ai_krisp
 COPY ./requirements.txt /app/base_requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/base_requirements.txt
 COPY ./app.py ./waiting_server.py /app/


### PR DESCRIPTION
Noticed this was at 3.10 but wanted to run a later version of Python. This also enables you to run a matrix build job and push a bunch of different python versions of your base image.

Happy to contribute a PR for that too.