### PR TITLE
[PCC-291] Use exec when running python to fix signal handling on termination

### DIFF
--- a/pipecat-base/Dockerfile
+++ b/pipecat-base/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir --upgrade -r /app/base_requirements.txt
 COPY ./app.py ./waiting_server.py /app/
 ARG VERSION
 ENV IMAGE_VERSION=$VERSION
-CMD ["sh", "-c", "if [ -f /app/pre-app.sh ]; then sh /app/pre-app.sh; fi && python app.py"]
+CMD ["sh", "-c", "if [ -f /app/pre-app.sh ]; then sh /app/pre-app.sh; fi && exec python app.py"]


### PR DESCRIPTION
This pull request includes a small but significant change to the `CMD` instruction in the `pipecat-base/Dockerfile`. The change ensures that the Python process replaces the shell process by using `exec`, which improves process management in containerized environments.

* [`pipecat-base/Dockerfile`](diffhunk://#diff-211cad0b3b0f9515bfe841cf3d3bad56ff7bb6150a15c155b22654de1ef883a9L10-R10): Updated the `CMD` instruction to use `exec` when running `python app.py`, ensuring the Python process becomes the main process in the container.