### PR TITLE
Add handle_sigint to *SessionArguments in the pipecat-base image

### DIFF
--- a/pipecat-base/CHANGELOG.md
+++ b/pipecat-base/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to the **Pipecat Cloud Base Images** will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.9] - TBD
+## [0.0.10] - TBD
+
+### Added
+
+- Added the `handle_sigint` session arg to `PipecatSessionArguments`,
+  `DailySessionArguments`, and `WebSocketSessionArguments`. The value defaults
+  to `False` for each option.
+
+## [0.0.9] - 2025-07-08
 
 ### Added
 

--- a/pipecat-base/CHANGELOG.md
+++ b/pipecat-base/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the **Pipecat Cloud Base Images** will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.10] - TBD
+## [0.0.10] - 2025-08-11
 
 ### Added
 

--- a/pipecat-base/app.py
+++ b/pipecat-base/app.py
@@ -15,7 +15,6 @@ from pipecatcloud.agent import (
     SessionArguments,
     WebSocketSessionArguments,
 )
-
 from waiting_server import Config, WaitingServer
 
 app = FastAPI()
@@ -67,11 +66,13 @@ async def handle_bot_request(
             room_url=x_daily_room_url,
             token=x_daily_room_token,
             body=body,
+            handle_sigint=False,
         )
     else:
         args = PipecatSessionArguments(
             session_id=x_daily_session_id,
             body=body,
+            handle_sigint=False,
         )
 
     await run_bot(args)
@@ -88,6 +89,7 @@ async def handle_websocket(
     args = WebSocketSessionArguments(
         session_id=x_daily_session_id,
         websocket=ws,
+        handle_sigint=False,
     )
 
     await run_bot(args)

--- a/pipecat-base/requirements.txt
+++ b/pipecat-base/requirements.txt
@@ -1,3 +1,3 @@
 fastapi[standard]~=0.115.0
 loguru~=0.7.3
-pipecatcloud
+pipecatcloud>=0.2.1

--- a/pipecat-starters/gemini_multimodal_live/bot.py
+++ b/pipecat-starters/gemini_multimodal_live/bot.py
@@ -31,7 +31,7 @@ from pipecat.transports.services.daily import DailyParams, DailyTransport
 load_dotenv(override=True)
 
 
-async def run_bot(transport: BaseTransport):
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     """Run your bot with the provided transport.
 
     Args:
@@ -115,7 +115,7 @@ async def run_bot(transport: BaseTransport):
         logger.info("Client disconnected: {}", participant)
         await task.cancel()
 
-    runner = PipelineRunner(handle_sigint=False, force_gc=True)
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint, force_gc=True)
 
     await runner.run(task)
 
@@ -149,7 +149,7 @@ async def bot(runner_args: RunnerArguments):
         return
 
     try:
-        await run_bot(transport)
+        await run_bot(transport, runner_args)
         logger.info("Bot process completed")
     except Exception as e:
         logger.exception(f"Error in bot process: {str(e)}")

--- a/pipecat-starters/natural_conversation/bot.py
+++ b/pipecat-starters/natural_conversation/bot.py
@@ -345,7 +345,7 @@ class OutputGate(FrameProcessor):
                 break
 
 
-async def run_bot(transport: BaseTransport):
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     """Run your bot with the provided transport.
 
     Args:
@@ -483,7 +483,7 @@ async def run_bot(transport: BaseTransport):
         logger.info("Client disconnected: {}", participant)
         await task.cancel()
 
-    runner = PipelineRunner(handle_sigint=False, force_gc=True)
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint, force_gc=True)
 
     await runner.run(task)
 
@@ -517,7 +517,7 @@ async def bot(runner_args: RunnerArguments):
         return
 
     try:
-        await run_bot(transport)
+        await run_bot(transport, runner_args)
         logger.info("Bot process completed")
     except Exception as e:
         logger.exception(f"Error in bot process: {str(e)}")

--- a/pipecat-starters/openai_realtime/bot.py
+++ b/pipecat-starters/openai_realtime/bot.py
@@ -34,7 +34,7 @@ from pipecat.transports.services.daily import DailyParams, DailyTransport
 load_dotenv(override=True)
 
 
-async def run_bot(transport: BaseTransport):
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     """Run your bot with the provided transport.
 
     Args:
@@ -114,7 +114,7 @@ async def run_bot(transport: BaseTransport):
         logger.info("Client disconnected: {}", participant)
         await task.cancel()
 
-    runner = PipelineRunner(handle_sigint=False, force_gc=True)
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint, force_gc=True)
 
     await runner.run(task)
 
@@ -148,7 +148,7 @@ async def bot(runner_args: RunnerArguments):
         return
 
     try:
-        await run_bot(transport)
+        await run_bot(transport, runner_args)
         logger.info("Bot process completed")
     except Exception as e:
         logger.exception(f"Error in bot process: {str(e)}")

--- a/pipecat-starters/pstn_sip/bot.py
+++ b/pipecat-starters/pstn_sip/bot.py
@@ -205,7 +205,7 @@ class DialOutHandler:
             logger.warning(f"Dial-out warning: {data}")
 
 
-async def run_bot(transport: BaseTransport, body: dict = {}):
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     """Run your bot with the provided transport.
 
     Args:
@@ -218,6 +218,7 @@ async def run_bot(transport: BaseTransport, body: dict = {}):
     dialin_settings = None
     dialled_phonenum = None
     caller_phonenum = None
+    body = runner_args.body or {}
     if raw_dialin_settings := body.get("dialin_settings"):
         # these fields can capitalize the first letter
         dialled_phonenum = raw_dialin_settings.get("To") or raw_dialin_settings.get("to")
@@ -402,7 +403,7 @@ async def run_bot(transport: BaseTransport, body: dict = {}):
         logger.debug(f"Participant left: {participant}, reason: {reason}")
         await task.cancel()
 
-    runner = PipelineRunner(handle_sigint=False, force_gc=True)
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint, force_gc=True)
     await runner.run(task)
 
 
@@ -435,7 +436,7 @@ async def bot(runner_args: RunnerArguments):
         return
 
     try:
-        await run_bot(transport, runner_args.body)
+        await run_bot(transport, runner_args)
         logger.info("Bot process completed")
     except Exception as e:
         logger.exception(f"Error in bot process: {str(e)}")

--- a/pipecat-starters/twilio/bot.py
+++ b/pipecat-starters/twilio/bot.py
@@ -28,7 +28,7 @@ from pipecat.transports.network.fastapi_websocket import (
 load_dotenv(override=True)
 
 
-async def run_bot(transport: BaseTransport):
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     """Run your bot with the provided transport.
 
     Args:
@@ -95,7 +95,7 @@ async def run_bot(transport: BaseTransport):
         logger.info(f"Client disconnected: {client}")
         await task.cancel()
 
-    runner = PipelineRunner(handle_sigint=False, force_gc=True)
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint, force_gc=True)
 
     await runner.run(task)
 
@@ -148,7 +148,7 @@ async def bot(runner_args: RunnerArguments):
         return
 
     try:
-        await run_bot(transport)
+        await run_bot(transport, runner_args)
         logger.info("Bot process completed")
     except Exception as e:
         logger.exception(f"Error in bot process: {str(e)}")

--- a/pipecat-starters/vision/bot.py
+++ b/pipecat-starters/vision/bot.py
@@ -82,7 +82,7 @@ class AnthropicContextWithVisionTool(AnthropicLLMContext):
         )
 
 
-async def run_bot(transport: BaseTransport):
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     """Run your bot with the provided transport.
 
     Args:
@@ -202,7 +202,7 @@ async def run_bot(transport: BaseTransport):
         logger.info("Client disconnected: {}", participant)
         await task.cancel()
 
-    runner = PipelineRunner(handle_sigint=False, force_gc=True)
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint, force_gc=True)
 
     await runner.run(task)
 
@@ -236,7 +236,7 @@ async def bot(runner_args: RunnerArguments):
         return
 
     try:
-        await run_bot(transport)
+        await run_bot(transport, runner_args)
         logger.info("Bot process completed")
     except Exception as e:
         logger.exception(f"Error in bot process: {str(e)}")

--- a/pipecat-starters/voice/bot.py
+++ b/pipecat-starters/voice/bot.py
@@ -25,7 +25,7 @@ from pipecat.transports.services.daily import DailyParams, DailyTransport
 load_dotenv(override=True)
 
 
-async def run_bot(transport: BaseTransport):
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     """Run your bot with the provided transport.
 
     Args:
@@ -106,7 +106,7 @@ async def run_bot(transport: BaseTransport):
         logger.info("Client disconnected: {}", participant)
         await task.cancel()
 
-    runner = PipelineRunner(handle_sigint=False, force_gc=True)
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint, force_gc=True)
 
     await runner.run(task)
 
@@ -140,7 +140,7 @@ async def bot(runner_args: RunnerArguments):
         return
 
     try:
-        await run_bot(transport)
+        await run_bot(transport, runner_args)
         logger.info("Bot process completed")
     except Exception as e:
         logger.exception(f"Error in bot process: {str(e)}")


### PR DESCRIPTION
We now support `handle_sigint` as a `RunnerArgument` in the Pipecat development runner. Also, in the Pipecat examples, the pattern of passing `runner_args.handle_sigint` is now used everywhere.

To avoid confusion, I'm proposing that we follow suit and add support for `handle_sigint` here, with the appropriate defaults set (False for all).

Related, I'm setting a minimum version for the `pipecatcloud` package, which should be 0.2.1 or greater due to the types changes to support the new deployment runner.

---

Then, use the new arg in the starter images.