### PR TITLE
Fix local builds to use 3.12 default

### DIFF
--- a/pipecat-base/Dockerfile
+++ b/pipecat-base/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim
 WORKDIR /app
 RUN apt update && apt install -y libopenblas-dev libresample1 libresample-dev && apt clean


### PR DESCRIPTION
CI/CD already built images correctly. The was left over and would only affect local builds. Now local builds will match the default python version of 3.12.