### PR TITLE
pipecat-base: allow executing bot() in a different process

### DIFF
--- a/pipecat-base/CHANGELOG.md
+++ b/pipecat-base/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the **Pipecat Cloud Base Images** will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2025-09-11
+
+### Added
+
+- Added a new environment variable `PIPECAT_CLOUD_SPAWN_PROCESS` that allows
+  controlling if the `bot()` function runs in a separate process every time. By
+  default, in a warm instance, subsequent calls to the `bot()` function will
+  always run in the same process. This environment variable does not apply to
+  websockets bots.
+
 ## [0.1.3] - 2025-09-09
 
 ### Added

--- a/pipecat-base/pyproject.toml
+++ b/pipecat-base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipecat-base"
-version = "0.1.3"
+version = "0.1.4"
 description = "Pipecat Cloud Base Image"
 requires-python = ">=3.10"
 dependencies = [

--- a/pipecat-base/uv.lock
+++ b/pipecat-base/uv.lock
@@ -671,7 +671,7 @@ wheels = [
 
 [[package]]
 name = "pipecat-base"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
This allows users to completely isolate each call to `bot()` in a separate process. By default, it's disabled. Note that this only applies to `/bot`, it does not apply to websockets.