### PR TITLE
Add body to WebsocketSessionArguments

### DIFF
--- a/pipecat-base/CHANGELOG.md
+++ b/pipecat-base/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the **Pipecat Cloud Base Images** will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2025-09-12
+
+### Added
+
+- Telnyx and Plivo websocket connections can now optionally receive custom
+  `body` information, which is provided via the `WebsocketSessionArguments`.
+
 ## [0.1.3] - 2025-09-09
 
 ### Added
@@ -17,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the ability to access the `FastAPI` application by extracting it into
-  a module named pipecatcloud_system.  This allows image developers to implement
+  a module named pipecatcloud_system. This allows image developers to implement
   API methods in their bot that are accessible while a session is in progress.
 
 ## [0.1.1] - 2025-08-22

--- a/pipecat-base/pyproject.toml
+++ b/pipecat-base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipecat-base"
-version = "0.1.3"
+version = "0.1.4"
 description = "Pipecat Cloud Base Image"
 requires-python = ">=3.10"
 dependencies = [

--- a/pipecat-base/uv.lock
+++ b/pipecat-base/uv.lock
@@ -671,7 +671,7 @@ wheels = [
 
 [[package]]
 name = "pipecat-base"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
DO NOT MERGE!

Wait for corresponding Pipecat Cloud PR to be released: https://github.com/daily-co/pipecat-cloud-sandbox/pull/265

---

Receives custom body data from PCC and injects it to bot() as `body` in the `WebsocketSessionArguments`.