### PR TITLE
Handling Pipecat-ai initialization failure by disabling WebRTC route.

### DIFF
--- a/pipecat-base/app.py
+++ b/pipecat-base/app.py
@@ -223,6 +223,9 @@ if SMALL_WEBRTC_AVAILABLE:
         SmallWebRTCRequestHandler = None
         IceServer = None
         logger.warning("pipecat-ai not available: WebRTC route disabled.")
+    # If we have an internal import issue inside Pipecat, it will be raised as an Exception rather than an ImportError.
+    except Exception as e:
+        logger.warning(f"pipecat-ai initialization failed: WebRTC route disabled. Error: {e}")
 
 
 # ------------------------------------------------------------


### PR DESCRIPTION
Handling Pipecat-ai initialization failure by disabling WebRTC route.