### PR TITLE
PCC-656: Publish timing events to event pipeline for later retrieval

### DIFF
--- a/pipecat-base/Dockerfile
+++ b/pipecat-base/Dockerfile
@@ -30,7 +30,7 @@ RUN VENV_SITE_PACKAGES=$(/app/.venv/bin/python -c "import site; print(site.getsi
     echo "/opt/krisp_viva/krisp_audio" > ${VENV_SITE_PACKAGES}/krisp_viva.pth
 
 # Copy application files
-COPY ./app.py ./waiting_server.py ./pipecatcloud_system.py ./feature_manager.py ./pcc_observers.py /app/
+COPY ./app.py ./waiting_server.py ./pipecatcloud_system.py ./feature_manager.py ./pcc_observers.py ./shared_state.py /app/
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/pipecat-base/app.py
+++ b/pipecat-base/app.py
@@ -24,6 +24,7 @@ from pipecatcloud.agent import (
     WebSocketSessionArguments,
 )
 from pipecatcloud_system import add_lifespan_to_app, app
+from shared_state import GLOBALS
 from waiting_server import Config, WaitingServer
 
 # ------------------------------------------------------------
@@ -53,8 +54,6 @@ async def _call_readyz_func(func: Callable[[], ReadyzResult]) -> ReadyzResult:
         return {"ready": False, "error": str(e)}
 
 
-# Global state dictionary
-GLOBALS = {}
 
 # Initialize feature manager
 feature_manager = FeatureManager()
@@ -96,6 +95,7 @@ async def run_bot(args: SessionArguments, transport_type: Optional[str] = None):
         "session_id": args.session_id,
         "image_version": image_version,
     }
+    GLOBALS["current_session_id"] = args.session_id
     with logger.contextualize(session_id=args.session_id):
         logger.info(f"Starting bot session with metadata: {json.dumps(metadata)}")
         logger.debug(f"Transport type: {transport_type}")

--- a/pipecat-base/pcc_observers.py
+++ b/pipecat-base/pcc_observers.py
@@ -10,7 +10,6 @@ automatically for Pipecat Cloud observability.
 
 import json
 import uuid
-from collections import OrderedDict
 from datetime import datetime, timezone
 from os import environ
 
@@ -19,6 +18,16 @@ from loguru import logger
 from shared_state import GLOBALS
 
 _event_publisher_endpoint = environ.get("PIPECAT_EVENT_PUBLISHER_ENDPOINT")
+_http_session: aiohttp.ClientSession | None = None
+
+
+def _get_http_session() -> aiohttp.ClientSession:
+    global _http_session
+    if _http_session is None or _http_session.closed:
+        _http_session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=5),
+        )
+    return _http_session
 
 
 async def _publish_event(event_name: str, event_properties: dict | None = None):
@@ -36,16 +45,12 @@ async def _publish_event(event_name: str, event_properties: dict | None = None):
         payload["event_properties"] = event_properties
 
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                _event_publisher_endpoint,
-                json=payload,
-                timeout=aiohttp.ClientTimeout(total=5),
-            ) as resp:
-                if resp.status >= 400:
-                    logger.warning(
-                        f"[pcc-observability] Event publish failed: {resp.status}"
-                    )
+        session = _get_http_session()
+        async with session.post(_event_publisher_endpoint, json=payload) as resp:
+            if resp.status >= 400:
+                logger.warning(
+                    f"[pcc-observability] Event publish failed: {resp.status}"
+                )
     except Exception as e:
         logger.warning(f"[pcc-observability] Event publish error: {e}")
 
@@ -88,7 +93,7 @@ async def _setup_startup_timing_observer(task):
 
     @observer.event_handler("on_transport_timing_report")
     async def on_transport_timing_report(observer, report):
-        properties = OrderedDict()
+        properties = {}
         properties["start_time"] = round(report.start_time, 3)
         if report.bot_connected_secs is not None:
             properties["bot_connected_secs"] = round(report.bot_connected_secs, 3)

--- a/pipecat-base/pcc_observers.py
+++ b/pipecat-base/pcc_observers.py
@@ -9,8 +9,45 @@ automatically for Pipecat Cloud observability.
 """
 
 import json
+import uuid
+from collections import OrderedDict
+from datetime import datetime, timezone
+from os import environ
 
+import aiohttp
 from loguru import logger
+from shared_state import GLOBALS
+
+_event_publisher_endpoint = environ.get("PIPECAT_EVENT_PUBLISHER_ENDPOINT")
+
+
+async def _publish_event(event_name: str, event_properties: dict | None = None):
+    """Publish an event to the event publisher endpoint if configured."""
+    if not _event_publisher_endpoint:
+        return
+
+    payload = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
+        "session_id": GLOBALS.get("current_session_id", "NONE"),
+        "event_name": event_name,
+        "event_uuid": str(uuid.uuid4()),
+    }
+    if event_properties:
+        payload["event_properties"] = event_properties
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                _event_publisher_endpoint,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                if resp.status >= 400:
+                    logger.warning(
+                        f"[pcc-observability] Event publish failed: {resp.status}"
+                    )
+    except Exception as e:
+        logger.warning(f"[pcc-observability] Event publish error: {e}")
 
 
 async def setup_pipeline_task(task):
@@ -43,15 +80,24 @@ async def _setup_startup_timing_observer(task):
             f" | total={report.total_duration_secs:.3f}s"
             f" | processors: {json.dumps(processors)}"
         )
+        await _publish_event("startup_timing", {
+            "start_time": round(report.start_time, 3),
+            "total_duration_secs": round(report.total_duration_secs, 3),
+            "processors": processors,
+        })
 
     @observer.event_handler("on_transport_timing_report")
     async def on_transport_timing_report(observer, report):
-        parts = [f"start_time={report.start_time:.3f}"]
+        properties = OrderedDict()
+        properties["start_time"] = round(report.start_time, 3)
         if report.bot_connected_secs is not None:
-            parts.append(f"bot_connected={report.bot_connected_secs:.3f}s")
+            properties["bot_connected_secs"] = round(report.bot_connected_secs, 3)
         if report.client_connected_secs is not None:
-            parts.append(f"client_connected={report.client_connected_secs:.3f}s")
-        logger.info(f"[pcc-observability] Transport timing | {' | '.join(parts)}")
+            properties["client_connected_secs"] = round(report.client_connected_secs, 3)
+
+        formatted = " | ".join(f"{k}={v}" for k, v in properties.items())
+        logger.info(f"[pcc-observability] Transport timing | {formatted}")
+        await _publish_event("transport_timing", properties)
 
     task.add_observer(observer)
 
@@ -67,6 +113,9 @@ async def _setup_user_bot_latency_observer(task):
     @observer.event_handler("on_latency_measured")
     async def on_latency_measured(observer, latency_seconds):
         logger.info(f"[pcc-observability] User-bot latency | latency={latency_seconds:.3f}s")
+        await _publish_event("user_bot_latency", {
+            "latency_secs": round(latency_seconds, 3),
+        })
 
     @observer.event_handler("on_latency_breakdown")
     async def on_latency_breakdown(observer, breakdown):
@@ -76,8 +125,16 @@ async def _setup_user_bot_latency_observer(task):
             start = f" start_time={breakdown.user_turn_start_time:.3f} |"
         logger.info(f"[pcc-observability] Latency breakdown |{start} events: {json.dumps(events)}")
 
+        properties = {"events": events}
+        if breakdown.user_turn_start_time is not None:
+            properties["start_time"] = round(breakdown.user_turn_start_time, 3)
+        await _publish_event("latency_breakdown", properties)
+
     @observer.event_handler("on_first_bot_speech_latency")
     async def on_first_bot_speech_latency(observer, latency_seconds):
         logger.info(f"[pcc-observability] First bot speech | latency={latency_seconds:.3f}s")
+        await _publish_event("first_bot_speech_latency", {
+            "latency_secs": round(latency_seconds, 3),
+        })
 
     task.add_observer(observer)

--- a/pipecat-base/shared_state.py
+++ b/pipecat-base/shared_state.py
@@ -1,0 +1,4 @@
+# Shared mutable state accessible across modules.
+# This avoids the __main__ double-import issue with app.py.
+
+GLOBALS = {}


### PR DESCRIPTION
This change publishes timing data to the new pcc event pipeline if the PIPECAT_EVENT_PUBLISHER_ENDPOINT env var is set. The hardest part of this was getting the session_id to propagate correctly – I had to move GLOBALS to a new module because of some wonkyness with imports from a file that's being run as __main__ vs the file as module. This is all working end-to-end now, though!