### PR TITLE
Make the structured-log file sink crash-durable (PCC-1038)

### DIFF
--- a/pipecat-base/CHANGELOG.md
+++ b/pipecat-base/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the **Pipecat Cloud Base Images** will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.25] - 2026-07-27
+
+### Fixed
+
+- Structured log file sink writes synchronously (was queued): the final log
+  lines before a hard process death (`os._exit`, SIGKILL) now reach disk and
+  ship with the crash tail. Captured stdout/stderr keep one async pump hop and
+  remain best-effort in the final microseconds — dying words said through the
+  logger are guaranteed. (PCC-1038)
+
 ## [0.1.24] - 2026-07-27
 
 ### Changed

--- a/pipecat-base/pcc_structured_logs.py
+++ b/pipecat-base/pcc_structured_logs.py
@@ -33,6 +33,14 @@ console sink may ever write to the *captured* descriptors — ``install()``
 removes loguru's default sink before capturing, and every console sink must
 use ``console_stream()`` (the saved real stderr) with ``console_filter``
 (which also keeps captured lines from being displayed twice).
+
+Crash durability (PCC-1038): the file sink writes synchronously (one
+line-buffered ``write()`` per record into the OS page cache), so framework-lane
+lines survive a hard process death (``os._exit``, SIGKILL) the instant the
+``logger.*`` call returns. Capture-lane lines have one unavoidable async hop —
+the pump thread must read the pipe before the process dies — so a ``print()``
+in the final microseconds before a hard exit is best-effort. Bots that want
+guaranteed dying words should say them through the logger.
 """
 
 import json
@@ -189,7 +197,15 @@ def add_file_sink(target_logger, level: str):
             rotation=_ROTATION,
             retention=_RETENTION,
             encoding="utf-8",
-            enqueue=True,  # never block the event loop on file I/O
+            # Synchronous on purpose (PCC-1038): loguru's file sink is
+            # line-buffered ("a", buffering=1), so each record is one write()
+            # into the OS page cache — which survives os._exit/SIGKILL, letting
+            # the shipper deliver a crashing bot's last words. enqueue=True
+            # routed records through a queue thread that a hard exit destroys,
+            # losing exactly the final-burst lines the crash tail exists for.
+            # Cost: µs-scale file I/O on the emitting thread — negligible at
+            # bot logging volumes.
+            enqueue=False,
         )
     except OSError as e:
         (_console_stream or sys.stderr).write(

--- a/pipecat-base/pyproject.toml
+++ b/pipecat-base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipecat-base"
-version = "0.1.24"
+version = "0.1.25"
 description = "Pipecat Cloud Base Image"
 requires-python = ">=3.10"
 dependencies = [

--- a/pipecat-base/tests/test_e2e_subprocess.py
+++ b/pipecat-base/tests/test_e2e_subprocess.py
@@ -112,3 +112,70 @@ def test_end_to_end(tmp_path):
     outside = by_line["printed outside session"]
     assert outside["stream"] == "stdout"
     assert "session_id" not in outside
+
+
+CRASH_CHILD = textwrap.dedent(
+    """
+    import os
+    import sys
+    import time
+
+    import pcc_structured_logs
+    pcc_structured_logs.install()
+
+    from loguru import logger
+
+    logger.remove()
+    logger.add(
+        pcc_structured_logs.console_stream() or sys.stderr,
+        format="{extra[session_id]} - {message}",
+        level="DEBUG",
+        filter=pcc_structured_logs.console_filter,
+    )
+    pcc_structured_logs.add_file_sink(logger, "DEBUG")
+    logger.configure(extra={"session_id": "NONE"})
+
+    with (
+        logger.contextualize(session_id="sess-crash"),
+        pcc_structured_logs.session_scope("sess-crash"),
+    ):
+        logger.info("pre-crash line")
+        print("crash-tail stdout marker", flush=True)
+        time.sleep(0.05)  # one pump-thread beat: the capture lane's async hop
+        logger.error("these are the dying words")
+        os._exit(17)  # hard death: no atexit, no flush, no loguru teardown
+    """
+)
+
+
+def test_crash_tail_survives_hard_exit(tmp_path):
+    """PCC-1038: framework-lane lines written in the final microseconds before
+    os._exit must be on disk (synchronous line-buffered writes to the page
+    cache) — with enqueue=True this deterministically loses the dying words.
+    The captured stdout marker gets one pump beat (50ms) — the capture lane's
+    documented best-effort hop — and must also survive."""
+    proc = subprocess.run(
+        [sys.executable, "-c", CRASH_CHILD],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "PCC_LOG_DIR": str(tmp_path)},
+        cwd=str(PIPECAT_BASE_DIR),
+    )
+    assert proc.returncode == 17
+
+    records = [
+        json.loads(line) for line in (tmp_path / "bot.jsonl").read_text().splitlines() if line
+    ]
+    by_line = {r["line"]: r for r in records}
+
+    # The last framework record before death — the whole point of PCC-1038.
+    dying = by_line["these are the dying words"]
+    assert dying["level"] == "ERROR"
+    assert dying["session_id"] == "sess-crash"
+
+    assert by_line["pre-crash line"]["session_id"] == "sess-crash"
+
+    marker = by_line["crash-tail stdout marker"]
+    assert marker["stream"] == "stdout"
+    assert marker["session_id"] == "sess-crash"

--- a/pipecat-base/uv.lock
+++ b/pipecat-base/uv.lock
@@ -984,7 +984,7 @@ wheels = [
 
 [[package]]
 name = "pipecat-base"
-version = "0.1.24"
+version = "0.1.25"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
## What

The PCC-1032 crash-tail e2e showed the runner's structured-log sink losing the final pre-crash records: with `enqueue=True`, loguru routes records through a queue thread that `os._exit` destroys before draining — the last ~30ms of a crashing bot's output (the lines the crash tail exists for) never reached disk. Dying words survived **1 of 3** crash runs.

## Fix

`enqueue=False`. loguru's file sink is line-buffered (`mode='a', buffering=1`), so each record is a single synchronous `write()` into the OS **page cache** — which survives `os._exit`/SIGKILL; Fluent Bit reads the page cache even after the process is gone. Cost: µs-scale file I/O on the emitting thread, negligible at bot logging volumes (the original "never block the event loop" comment traded away exactly the records that matter most).

## Verified

- **Regression test with teeth**: new subprocess test hard-exits (`os._exit(17)`) immediately after its last `logger.error` — deterministically **fails under `enqueue=True`** (verified by flipping it back: `KeyError: 'these are the dying words'`, the exact production symptom) and passes now. Suite 20/20.
- **Docker acceptance repro** (base built from this branch + the logging-e2e fixture, `{"crash": true}` × 3): framework-lane dying words **3/3** (was 0/3).

## Scope honesty

Captured stdout/stderr keeps one unavoidable async hop — the pump thread must read the pipe before the process dies — so a `print()` in the final microseconds before a hard exit remains best-effort (0/3 in the repro; nothing fd-level can read a pipe after the writer's process is gone). Documented in the module docstring. The lane that matters is guaranteed: the runner's real crash reporting (`run_bot`'s exception handler) speaks through the logger, and bots that want guaranteed dying words should too.

CHANGELOG 0.1.24 + lockfile refresh included (the #98 lesson).