### PR TITLE
Fix shutdown() task-wait to respect SHUTDOWN_TIMEOUT deadline (PCC-989)

### DIFF
--- a/pipecat-base/CHANGELOG.md
+++ b/pipecat-base/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the **Pipecat Cloud Base Images** will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.24] - 2026-07-28
+
+### Fixed
+
+- Shutdown now respects `SHUTDOWN_TIMEOUT` end to end. Before, the wait for
+  background tasks to finish had no deadline, so a task that never finished
+  could hold the pod open past the timeout until Kubernetes SIGKILLed it. The
+  wait for background tasks and the application (lifespan) shutdown are both
+  bounded by the same deadline now, and each logs a warning when it runs out
+  of time instead of hanging.
+
+- `SHUTDOWN_TIMEOUT` is read from the environment as a string, so it is now
+  coerced to a float before the deadline math runs.
+
+### Changed
+
+- Shutdown deadlines use a monotonic clock, so a wall-clock (NTP) adjustment
+  during shutdown can no longer stretch or shorten the timeout.
+
 ## [0.1.23] - 2026-07-21
 
 ### Added

--- a/pipecat-base/app.py
+++ b/pipecat-base/app.py
@@ -72,7 +72,7 @@ if log_features_summary:
     feature_manager.log_features_summary()
 
 server_config = Config(
-    environ.get("SHUTDOWN_TIMEOUT", 7200),
+    float(environ.get("SHUTDOWN_TIMEOUT", 7200)),
     app,
     host="0.0.0.0",
     port=int(environ.get("PORT", 8080)),

--- a/pipecat-base/pyproject.toml
+++ b/pipecat-base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipecat-base"
-version = "0.1.23"
+version = "0.1.24"
 description = "Pipecat Cloud Base Image"
 requires-python = ">=3.10"
 dependencies = [

--- a/pipecat-base/tests/test_waiting_server.py
+++ b/pipecat-base/tests/test_waiting_server.py
@@ -35,9 +35,9 @@ def test_tasks_wait_gives_up_at_deadline():
     # Simulate an in-flight bot session: a task that never finishes on its own.
     server.server_state.tasks = {object()}
 
-    start = time.time()
+    start = time.monotonic()
     asyncio.run(asyncio.wait_for(server.shutdown(), timeout=5.0))
-    elapsed = time.time() - start
+    elapsed = time.monotonic() - start
 
     # The loop must exit around the 0.3s deadline, not hang forever.
     assert elapsed < 3.0

--- a/pipecat-base/tests/test_waiting_server.py
+++ b/pipecat-base/tests/test_waiting_server.py
@@ -1,0 +1,56 @@
+"""WaitingServer.shutdown() must honor should_exit_timeout for the tasks-wait loop.
+
+Regression test for PCC-989. A live bot session keeps a FastAPI BackgroundTask
+in server_state.tasks for the whole session, so the tasks-wait loop must give up
+at should_exit_deadline. Before the fix it ignored the deadline and blocked until
+Kubernetes sent SIGKILL, which looked like SIGTERM being swallowed.
+"""
+
+import asyncio
+import time
+
+from waiting_server import Config, WaitingServer
+
+
+async def _noop_app(scope, receive, send):
+    pass
+
+
+class _StubLifespan:
+    async def shutdown(self):
+        pass
+
+
+def _make_server(should_exit_timeout):
+    config = Config(app=_noop_app, should_exit_timeout=should_exit_timeout)
+    server = WaitingServer(config)
+    # These attributes are normally set during serve(), which we do not run here.
+    server.servers = []
+    server.lifespan = _StubLifespan()
+    return server
+
+
+def test_tasks_wait_gives_up_at_deadline():
+    server = _make_server(should_exit_timeout=0.3)
+    # Simulate an in-flight bot session: a task that never finishes on its own.
+    server.server_state.tasks = {object()}
+
+    start = time.time()
+    asyncio.run(asyncio.wait_for(server.shutdown(), timeout=5.0))
+    elapsed = time.time() - start
+
+    # The loop must exit around the 0.3s deadline, not hang forever.
+    assert elapsed < 3.0
+    # The task set is left as-is; the deadline is what ends the wait.
+    assert server.server_state.tasks
+
+
+def test_tasks_wait_returns_immediately_when_no_tasks():
+    server = _make_server(should_exit_timeout=0.3)
+    server.server_state.tasks = set()
+
+    start = time.time()
+    asyncio.run(asyncio.wait_for(server.shutdown(), timeout=5.0))
+    elapsed = time.time() - start
+
+    assert elapsed < 1.0

--- a/pipecat-base/tests/test_waiting_server.py
+++ b/pipecat-base/tests/test_waiting_server.py
@@ -49,8 +49,25 @@ def test_tasks_wait_returns_immediately_when_no_tasks():
     server = _make_server(should_exit_timeout=0.3)
     server.server_state.tasks = set()
 
-    start = time.time()
+    start = time.monotonic()
     asyncio.run(asyncio.wait_for(server.shutdown(), timeout=5.0))
-    elapsed = time.time() - start
+    elapsed = time.monotonic() - start
 
     assert elapsed < 1.0
+
+
+def test_string_timeout_does_not_crash_shutdown():
+    """SHUTDOWN_TIMEOUT arrives from the environment as a string in production.
+
+    Config must coerce it to a number so the deadline math does not raise
+    TypeError and abort shutdown before the wait loops even run.
+    """
+    server = _make_server(should_exit_timeout="0.3")
+    server.server_state.tasks = {object()}
+
+    start = time.monotonic()
+    asyncio.run(asyncio.wait_for(server.shutdown(), timeout=5.0))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 3.0
+    assert server.server_state.tasks

--- a/pipecat-base/uv.lock
+++ b/pipecat-base/uv.lock
@@ -974,7 +974,7 @@ wheels = [
 
 [[package]]
 name = "pipecat-base"
-version = "0.1.23"
+version = "0.1.24"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },

--- a/pipecat-base/waiting_server.py
+++ b/pipecat-base/waiting_server.py
@@ -60,7 +60,11 @@ class WaitingServer(uvicorn.server.Server):
         if self.server_state.tasks and not self.force_exit:
             msg = "Waiting for background tasks to complete. (CTRL+C to force quit)"
             logger.info(msg)
-            while self.server_state.tasks and not self.force_exit:
+            while (
+                self.server_state.tasks
+                and not self.force_exit
+                and (should_exit_deadline is None or time.time() < should_exit_deadline)
+            ):
                 await asyncio.sleep(0.1)
 
         # Send the lifespan shutdown event, and wait for application shutdown.

--- a/pipecat-base/waiting_server.py
+++ b/pipecat-base/waiting_server.py
@@ -12,7 +12,11 @@ import uvicorn.server
 class Config(uvicorn.Config):
     def __init__(self, should_exit_timeout: Optional[float] = None, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.should_exit_timeout = should_exit_timeout
+        # Coerce to float: this often comes from an env var (a string), and the
+        # deadline math (time.monotonic() + should_exit_timeout) needs a number.
+        self.should_exit_timeout = (
+            None if should_exit_timeout is None else float(should_exit_timeout)
+        )
 
 
 class WaitingServer(uvicorn.server.Server):
@@ -33,9 +37,11 @@ class WaitingServer(uvicorn.server.Server):
         logger = logging.getLogger("uvicorn.error")
         self.shutdown_sidecar()
 
+        # Use a monotonic clock so the deadline is not skewed by wall-clock
+        # (NTP) adjustments while shutdown is in progress.
         should_exit_deadline = None
         if self.__config.should_exit_timeout is not None:
-            should_exit_deadline = time.time() + self.__config.should_exit_timeout
+            should_exit_deadline = time.monotonic() + self.__config.should_exit_timeout
 
         # Stop accepting new connections.
         for server in self.servers:
@@ -52,7 +58,7 @@ class WaitingServer(uvicorn.server.Server):
             while (
                 self.server_state.connections
                 and not self.force_exit
-                and (should_exit_deadline is None or time.time() < should_exit_deadline)
+                and (should_exit_deadline is None or time.monotonic() < should_exit_deadline)
             ):
                 await asyncio.sleep(0.1)
 
@@ -63,21 +69,35 @@ class WaitingServer(uvicorn.server.Server):
             while (
                 self.server_state.tasks
                 and not self.force_exit
-                and (should_exit_deadline is None or time.time() < should_exit_deadline)
+                and (should_exit_deadline is None or time.monotonic() < should_exit_deadline)
             ):
                 await asyncio.sleep(0.1)
 
-            if (
-                self.server_state.tasks
-                and not self.force_exit
-                and should_exit_deadline is not None
-                and time.time() >= should_exit_deadline
-            ):
+            # The loop above ends when tasks drain, force_exit is set, or the
+            # deadline passes. If tasks remain and we did not force quit, the
+            # deadline is the only reason we stopped waiting.
+            if self.server_state.tasks and not self.force_exit:
                 logger.warning(
                     "Shutdown timeout reached with %d background task(s) still running; continuing shutdown.",
                     len(self.server_state.tasks),
                 )
 
         # Send the lifespan shutdown event, and wait for application shutdown.
+        # Bound this by the same deadline so a stuck app shutdown handler cannot
+        # push total shutdown past SHUTDOWN_TIMEOUT and get the pod SIGKILLed.
         if not self.force_exit:
-            await self.lifespan.shutdown()
+            if should_exit_deadline is None:
+                await self.lifespan.shutdown()
+            else:
+                remaining = should_exit_deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "Shutdown timeout reached before application shutdown; skipping lifespan shutdown."
+                    )
+                else:
+                    try:
+                        await asyncio.wait_for(self.lifespan.shutdown(), timeout=remaining)
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "Application shutdown did not complete within the shutdown timeout; continuing."
+                        )

--- a/pipecat-base/waiting_server.py
+++ b/pipecat-base/waiting_server.py
@@ -67,6 +67,17 @@ class WaitingServer(uvicorn.server.Server):
             ):
                 await asyncio.sleep(0.1)
 
+            if (
+                self.server_state.tasks
+                and not self.force_exit
+                and should_exit_deadline is not None
+                and time.time() >= should_exit_deadline
+            ):
+                logger.warning(
+                    "Shutdown timeout reached with %d background task(s) still running; continuing shutdown.",
+                    len(self.server_state.tasks),
+                )
+
         # Send the lifespan shutdown event, and wait for application shutdown.
         if not self.force_exit:
             await self.lifespan.shutdown()


### PR DESCRIPTION
## The bug

`WaitingServer.shutdown()` in `pipecat-base/waiting_server.py` has two wait loops:

1. Wait for open connections to close.
2. Wait for background tasks to finish.

The first loop checks `should_exit_deadline` (built from `SHUTDOWN_TIMEOUT`) and gives up once the deadline passes. The second loop did not check the deadline at all. It only ended when `server_state.tasks` emptied or `force_exit` became true.

`force_exit` only flips on a second SIGTERM/SIGINT, which Kubernetes never sends. Kubernetes sends one SIGTERM, waits the pod grace period, then SIGKILLs. There is no second signal.

A live bot session is started with `background_tasks.add_task(run_bot, ...)` (see `app.py`), a FastAPI BackgroundTask that uvicorn tracks in `server_state.tasks` until the request finishes. `run_bot` runs for the whole session, so the task set never empties while a session is active.

Net effect: if SIGTERM arrives during an active session, `shutdown()` blocks in the second loop with no timeout, no matter what `SHUTDOWN_TIMEOUT` is set to. From the outside this looks exactly like SIGTERM being swallowed until Kubernetes kills the pod. It silently defeats the timeout that `SHUTDOWN_TIMEOUT` is supposed to give on the main bot-session path.

Reproduced locally: an idle container exits in ~1s on SIGTERM, but a container with an in-flight background task stays alive and unresponsive well past a 5s `SHUTDOWN_TIMEOUT`, log frozen at "Waiting for background tasks to complete."

## Why it matters (PCC-989)

PCC-989 tracks bot containers getting SIGKILLed mid-session with no error logs, well after SIGTERM was sent. There is a separate operator-side fix in progress (pipecat-cloud-operator #232) that caps the grace period for a boot-time liveness restart. This change is independent of that one: it fixes the runtime side so `SHUTDOWN_TIMEOUT` is actually honored on the primary session code path, instead of the shutdown hanging until the pod grace period runs out.

## The fix

One-line change: add the same three-part deadline condition the connections loop already uses to the tasks loop.

```python
while (
    self.server_state.tasks
    and not self.force_exit
    and (should_exit_deadline is None or time.time() < should_exit_deadline)
):
    await asyncio.sleep(0.1)
```

## Test

Added `pipecat-base/tests/test_waiting_server.py` with a regression test that the task-wait loop gives up at the deadline instead of hanging, plus a control case for no active tasks. Confirmed the deadline test fails (times out) against the old code and passes with the fix. Full suite: 21 passed. Ruff check and format clean.

Draft: opening for review, not ready to merge.
