### PR TITLE
Fix security vulnerabilities in nltk, pip, and pydantic-settings

### DIFF
--- a/pipecat-base/CHANGELOG.md
+++ b/pipecat-base/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the **Pipecat Cloud Base Images** will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.24] - 2026-07-27
+
+### Changed
+
+- Bumped minimum `nltk` from `>=3.9.4` to `>=3.10.0`. nltk 3.10.0 sandboxes
+  file access to directories listed in `nltk.data.path`. The base image's
+  pre-downloaded `punkt_tab` data is unaffected, but bots that read or
+  download nltk data from a custom directory must now authorize it via
+  `nltk.data.path.append(...)` or `NLTK_DATA`, or nltk raises
+  `PermissionError`.
+
+### Security
+
+- Update dependencies to resolve security vulnerabilities: nltk 3.9.4 to
+  3.10.0, pip 26.1.1 to 26.1.2, pydantic-settings 2.12.0 to 2.14.2.
+
 ## [0.1.23] - 2026-07-21
 
 ### Added

--- a/pipecat-base/pyproject.toml
+++ b/pipecat-base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipecat-base"
-version = "0.1.23"
+version = "0.1.24"
 description = "Pipecat Cloud Base Image"
 requires-python = ">=3.10"
 dependencies = [
@@ -8,7 +8,7 @@ dependencies = [
     "loguru~=0.7.3",
     "pipecatcloud>=0.4.4",
     "pip>=26.1",
-    "nltk>=3.9.4,<4",
+    "nltk>=3.10.0,<4",
 ]
 
 [dependency-groups]

--- a/pipecat-base/uv.lock
+++ b/pipecat-base/uv.lock
@@ -242,6 +242,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -950,31 +959,32 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
 ]
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
 name = "pipecat-base"
-version = "0.1.23"
+version = "0.1.24"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
@@ -988,7 +998,7 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.6,<1" },
     { name = "loguru", specifier = "~=0.7.3" },
-    { name = "nltk", specifier = ">=3.9.4,<4" },
+    { name = "nltk", specifier = ">=3.10.0,<4" },
     { name = "pip", specifier = ">=26.1" },
     { name = "pipecatcloud", specifier = ">=0.4.4" },
 ]
@@ -1295,16 +1305,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.12.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumped `pipecat-base` to **0.1.24**.
- Updated dependencies to resolve Dependabot alerts: nltk 3.9.4→3.10.0 (GHSA-p4gq-832x-fm9v, high), pip 26.1.1→26.1.2 (GHSA-wf93-45jw-7689), pydantic-settings 2.12.0→2.14.2 (GHSA-4xgf-cpjx-pc3j). nltk is a direct dependency, so its floor moved from `>=3.9.4` to `>=3.10.0`.
- Refreshed `pipecat-base/uv.lock`.

## Notes for reviewers

- **nltk 3.10.0 is a behavioral change, not just a patch.** The advisory fix adds `nltk/pathsec.py`, which sandboxes all nltk file access to directories listed in `nltk.data.path` (plus `NLTK_DATA`, `~/nltk_data`, `/usr/share/nltk_data`, tempdir). Writes outside those roots now raise `PermissionError`.
- The image is unaffected: the Dockerfile downloads `punkt_tab` to `/usr/local/share/nltk_data`, which is a default `nltk.data.path` entry and therefore an allowed root. I verified this on 3.10.0 — download and unzip complete end-to-end into an allowed root, and the runtime `nltk.data.find` lookup reads from one too. Downloading to a *non*-listed directory fails with `PermissionError`, drops into an interactive retry prompt, and exits 1, so this was worth confirming before the build.
- Downstream bots that read or download nltk data from a custom directory do need to authorize it (`nltk.data.path.append(...)` or `NLTK_DATA`). Called out in the changelog.
- nltk 3.10.0 adds a new runtime dependency, `defusedxml` 0.7.1.
- The lockfile's own `pipecat-base` entry was stale at 0.1.23 while `pyproject.toml` said 0.1.24. The Dockerfile runs `uv sync --locked`, which fails on that mismatch, so the image build would have broken. Fixed in the lock refresh.
- Verification: 19 tests pass, `ruff check` clean, `uv lock --check` clean in both the root and `pipecat-base/`. Docker build not run locally (no daemon); CI's PR build covers it.

## Not covered here

Two Dependabot alerts remain against the **root** `uv.lock`. Both are dev tooling only — nothing that ships in the image:

- `pipecat-ai` 0.0.108 (2 high) — present only in the `python_full_version < '3.11'` resolution fork; 3.11+ already resolves to 1.6.0. Clearing it means raising the root `requires-python` to `>=3.11`, which lines up with the Python 3.10 deprecation noted in 0.1.18 but is a separate change.
- `pytest` (medium) — needs 9.0.3; the root pins `pytest~=8.4`.

## Release

Merging to `main` cuts the release — `docker-publish.yml` reads the version from `pipecat-base/pyproject.toml` and builds/pushes the `0.1.24` and `latest` tags. The changelog currently dates 0.1.24 as 2026-07-27; worth adjusting at merge time if that slips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
