### PR TITLE
feat(pipecat-base): enforce the platform's session budget in-process (PCC-1066)

### DIFF
--- a/pipecat-base/CHANGELOG.md
+++ b/pipecat-base/CHANGELOG.md
@@ -11,19 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The maximum session duration configured for your service is now enforced
   inside the bot process. When a session reaches the limit, `bot()` is
-  cancelled and the pipeline shuts down. Previously the limit closed the
-  platform's connection to the bot, which a bot using an HTTP transport (for
-  example a Daily/WebRTC room) had no way to observe, so the session carried
-  on running past its limit.
+  cancelled. Previously the limit closed the platform's own request to the bot,
+  which a bot whose session is started by an HTTP request had no way to observe
+  — it connects its own media transport (a Daily room, for example) — so the
+  session carried on running past its limit.
 
   **This changes behaviour for sessions that currently overrun.** If your
   agent legitimately runs longer than its configured limit, raise
   `maxSessionDuration` (up to 4 hours) before adopting this version.
 
-  Cancellation is a graceful pipeline shutdown, not a kill: Pipecat unwinds the
-  pipeline and runs each processor's `cleanup()`. It is not a chance for the bot
-  to say goodbye, though — if you want that, keep your own timer that fires
-  before the limit.
+  If your bot runs its pipeline through `PipelineRunner`, the runner absorbs the
+  cancellation and unwinds the pipeline for you, so each processor's `cleanup()`
+  still runs. Otherwise `bot()` sees a `CancelledError` wherever it is awaiting
+  and cleanup is up to you. Either way it is not a chance for the bot to say
+  goodbye — if you want that, keep your own timer that fires before the limit.
 
 ## [0.1.26] - 2026-07-28
 

--- a/pipecat-base/CHANGELOG.md
+++ b/pipecat-base/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the **Pipecat Cloud Base Images** will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.27] - 2026-07-31
+
+### Added
+
+- The maximum session duration configured for your service is now enforced
+  inside the bot process. When a session reaches the limit, `bot()` is
+  cancelled and the pipeline shuts down. Previously the limit closed the
+  platform's connection to the bot, which a bot using an HTTP transport (for
+  example a Daily/WebRTC room) had no way to observe, so the session carried
+  on running past its limit.
+
+  **This changes behaviour for sessions that currently overrun.** If your
+  agent legitimately runs longer than its configured limit, raise
+  `maxSessionDuration` (up to 4 hours) before adopting this version.
+
+  Cancellation is a graceful pipeline shutdown, not a kill: Pipecat unwinds the
+  pipeline and runs each processor's `cleanup()`. It is not a chance for the bot
+  to say goodbye, though — if you want that, keep your own timer that fires
+  before the limit.
+
 ## [0.1.26] - 2026-07-28
 
 ### Fixed

--- a/pipecat-base/app.py
+++ b/pipecat-base/app.py
@@ -114,10 +114,10 @@ image_version = environ.get("IMAGE_VERSION", "unknown")
 
 # Header carrying the session budget Pipecat Cloud has configured for this
 # service (`maxSessionDuration`). Enforcing it here is the only way the cap can
-# actually stop the bot: the platform can close its own request to us, but on
-# HTTP transports the media runs directly between this process and the transport
-# provider, so closing that request is invisible to bot() and the session simply
-# carries on.
+# actually stop the bot: the platform can close its own request to us, but when
+# a session is started by an HTTP request the bot goes on to connect its own
+# media transport (a Daily room, say), so closing that request is invisible to
+# bot() and the session simply carries on.
 #
 # There is deliberately no default. Only the platform knows the configured
 # value, so an absent header means "not supplied" and nothing is enforced.
@@ -183,6 +183,23 @@ def _parse_budget(raw: Optional[str]) -> Optional[float]:
     return budget
 
 
+def _cancellation_requested_on_self() -> bool:
+    """Has something cancelled the task running this coroutine?
+
+    Distinguishes "we cancelled the bot" from "someone cancelled us", which
+    matters while the bot is unwinding after the budget fired.
+
+    ``Task.cancelling()`` is 3.11+. Base images are built for 3.10 too (the
+    default is 3.12), so on 3.10 we cannot tell the two apart and fall back to
+    treating the cancellation as ours. The cost is confined to a teardown that
+    lands inside the bot's unwind window — a few tens of milliseconds — on a pod
+    that is going away regardless.
+    """
+    task = asyncio.current_task()
+    cancelling = getattr(task, "cancelling", None)
+    return bool(cancelling and cancelling())
+
+
 async def _run_bot_with_budget(args: SessionArguments) -> None:
     """Run bot(args), stopping it if it outlives the platform's session budget.
 
@@ -213,7 +230,13 @@ async def _run_bot_with_budget(args: SessionArguments) -> None:
     except asyncio.CancelledError:
         # Only swallow the cancellation we asked for. Anything else means this
         # process is going away, and the caller needs to see that.
-        if run.cancel_reason is None:
+        #
+        # cancel_reason alone is not enough to tell them apart: it stays set for
+        # the rest of the session, so a teardown arriving while the bot is still
+        # unwinding would look like our own deadline. We cancel the *bot* task
+        # and never this one, so a pending cancellation against this task can
+        # only have come from outside.
+        if run.cancel_reason is None or _cancellation_requested_on_self():
             raise
     finally:
         if deadline_task is not None:

--- a/pipecat-base/app.py
+++ b/pipecat-base/app.py
@@ -16,7 +16,7 @@ import logging
 import sys
 from contextlib import asynccontextmanager
 from os import environ
-from typing import Annotated, Callable, List, Optional, Union
+from typing import Annotated, Callable, Dict, List, Optional, Union
 
 import aiohttp
 import bot as bot_module
@@ -112,6 +112,122 @@ logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
 
 image_version = environ.get("IMAGE_VERSION", "unknown")
 
+# Header carrying the session budget Pipecat Cloud has configured for this
+# service (`maxSessionDuration`). Enforcing it here is the only way the cap can
+# actually stop the bot: the platform can close its own request to us, but on
+# HTTP transports the media runs directly between this process and the transport
+# provider, so closing that request is invisible to bot() and the session simply
+# carries on.
+#
+# There is deliberately no default. Only the platform knows the configured
+# value, so an absent header means "not supplied" and nothing is enforced.
+# Guessing would cut sessions short for anyone configured above the guess.
+MAX_SESSION_SECONDS_HEADER = "X-PCC-Max-Session-Seconds"
+
+_BUDGET_KEY = "pcc_session_budget"
+_warned_no_budget = False
+
+
+class _SessionRun:
+    """A running bot() call plus the reason it was stopped, if it was.
+
+    Cancellation is routed through here rather than cancelling the task
+    directly so that the reason survives, and so that a caller cancelling the
+    session is distinguishable from this process being torn down.
+    """
+
+    def __init__(self, task: "asyncio.Task"):
+        self.task = task
+        self.cancel_reason: Optional[str] = None
+
+    def cancel(self, reason: str) -> bool:
+        """Stop the bot. Returns False if it had already finished."""
+        if self.task.done():
+            return False
+        self.cancel_reason = reason
+        self.task.cancel()
+        return True
+
+
+# Sessions currently running bot(), keyed by session id. The session budget is
+# the only caller today; a platform "stop this session" request would reuse the
+# same primitive.
+_active_sessions: Dict[str, _SessionRun] = {}
+
+
+def _session_budget_seconds() -> Optional[float]:
+    """The platform's session budget for the current session, if it supplied one."""
+    global _warned_no_budget
+    budget = GLOBALS.get(_BUDGET_KEY)
+    if budget is None and not _warned_no_budget:
+        _warned_no_budget = True
+        logger.info(
+            "No session budget supplied by the platform "
+            f"({MAX_SESSION_SECONDS_HEADER} absent); the maximum session "
+            "duration will not be enforced inside this process."
+        )
+    return budget
+
+
+def _parse_budget(raw: Optional[str]) -> Optional[float]:
+    if raw is None:
+        return None
+    try:
+        budget = float(raw)
+    except ValueError:
+        logger.warning(f"Ignoring malformed {MAX_SESSION_SECONDS_HEADER}: {raw!r}")
+        return None
+    if budget <= 0:
+        logger.warning(f"Ignoring non-positive {MAX_SESSION_SECONDS_HEADER}: {raw!r}")
+        return None
+    return budget
+
+
+async def _run_bot_with_budget(args: SessionArguments) -> None:
+    """Run bot(args), stopping it if it outlives the platform's session budget.
+
+    Cancelling is a graceful shutdown for a Pipecat pipeline, not a hard kill:
+    WorkerRunner absorbs the CancelledError and unwinds the pipeline normally
+    (CancelFrame through the processors, cleanup() on each). A bot that lets the
+    CancelledError propagate instead is also fine — either way this returns and
+    the caller's HTTP response is sent, which is what tells the platform the pod
+    is free again.
+    """
+    session_id = args.session_id
+    run = _SessionRun(asyncio.create_task(bot(args)))
+    if session_id:
+        _active_sessions[session_id] = run
+
+    budget = _session_budget_seconds()
+    deadline_task: Optional[asyncio.Task] = None
+    if budget is not None:
+
+        async def _deadline():
+            await asyncio.sleep(budget)
+            run.cancel(f"maximum session duration reached ({budget:g}s)")
+
+        deadline_task = asyncio.create_task(_deadline())
+
+    try:
+        await run.task
+    except asyncio.CancelledError:
+        # Only swallow the cancellation we asked for. Anything else means this
+        # process is going away, and the caller needs to see that.
+        if run.cancel_reason is None:
+            raise
+    finally:
+        if deadline_task is not None:
+            deadline_task.cancel()
+        if session_id:
+            _active_sessions.pop(session_id, None)
+
+    # Checked after the await as well as in the except: a Pipecat bot absorbs
+    # the cancellation and returns normally, so the exception arm alone would
+    # miss the common case.
+    if run.cancel_reason:
+        logger.warning(f"Bot session stopped: {run.cancel_reason}")
+
+
 if feature_manager.is_enabled(FeatureKeys.SMALL_WEBRTC_SESSION):
     from pipecatcloud import SmallWebRTCSessionManager
     from pipecatcloud.agent import SmallWebRTCSessionArguments
@@ -153,7 +269,7 @@ async def run_bot(args: SessionArguments, transport_type: Optional[str] = None):
                     args.body = GLOBALS.get("pipecat_session_body")
 
         try:
-            await bot(args)
+            await _run_bot_with_budget(args)
         except Exception as e:
             logger.error(f"Exception running bot(): {e}")
         finally:
@@ -212,7 +328,14 @@ async def handle_bot_request(
     x_daily_room_token: Annotated[str | None, Header()] = None,
     x_daily_session_id: Annotated[str | None, Header()] = None,
     x_daily_transport_type: Annotated[str | None, Header()] = None,
+    x_pcc_max_session_seconds: Annotated[str | None, Header()] = None,
 ):
+    # Stashed rather than passed down because SmallWebRTC runs the bot from a
+    # different request: this one only waits for the WebRTC connection, and the
+    # actual bot() call happens in the /api/offer background task, which never
+    # sees these headers. Same reason pipecat_session_body is stashed below.
+    GLOBALS[_BUDGET_KEY] = _parse_budget(x_pcc_max_session_seconds)
+
     if x_daily_room_url and x_daily_room_token:
         args = DailySessionArguments(
             session_id=x_daily_session_id,

--- a/pipecat-base/pyproject.toml
+++ b/pipecat-base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipecat-base"
-version = "0.1.26"
+version = "0.1.27"
 description = "Pipecat Cloud Base Image"
 requires-python = ">=3.10"
 dependencies = [

--- a/pipecat-base/tests/test_session_budget.py
+++ b/pipecat-base/tests/test_session_budget.py
@@ -1,0 +1,274 @@
+"""PCC-1066: the platform's session budget is enforced inside this process.
+
+Pipecat Cloud caps sessions at ``maxSessionDuration``, but the only thing it can
+do from outside is close its own request to us. On HTTP transports the media
+runs directly between this process and the transport provider, so that close is
+invisible to ``bot()`` and the session carries on — which is how a pod ended up
+running two live pipelines at once. The platform now sends its budget on the
+``/bot`` request and we stop the bot ourselves.
+
+Two behaviours here are easy to get wrong and are pinned deliberately:
+
+* A Pipecat bot **absorbs** the cancellation (WorkerRunner catches it and
+  unwinds the pipeline normally), so nothing is raised. Detection based only on
+  catching an exception misses the common case.
+* Cancellation we did **not** ask for — this process being torn down — must
+  still propagate.
+"""
+
+import asyncio
+import sys
+import types
+from functools import wraps
+from types import SimpleNamespace
+
+import pytest
+
+
+def sync(fn):
+    """Run a coroutine test body. This repo has no pytest-asyncio plugin."""
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(fn(*args, **kwargs))
+
+    return wrapper
+
+
+# app.py does `from bot import bot` at import time; the real module is supplied
+# by the customer's image.
+if "bot" not in sys.modules:
+    _stub = types.ModuleType("bot")
+
+    async def _noop_bot(args):
+        return None
+
+    _stub.bot = _noop_bot
+    sys.modules["bot"] = _stub
+
+import app  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean_budget():
+    app.GLOBALS.pop(app._BUDGET_KEY, None)
+    app._active_sessions.clear()
+    yield
+    app.GLOBALS.pop(app._BUDGET_KEY, None)
+    app._active_sessions.clear()
+
+
+def _args(session_id="sess-1"):
+    return SimpleNamespace(session_id=session_id, body=None)
+
+
+class TestBudgetEnforcement:
+    @sync
+    async def test_absorbing_bot_is_stopped_and_returns_cleanly(self, monkeypatch):
+        """The Pipecat shape: the runner swallows the cancel and tears down."""
+        saw_cancel = asyncio.Event()
+
+        async def fake_bot(args):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                saw_cancel.set()
+                # Graceful teardown, then return normally — no re-raise.
+            await asyncio.sleep(0)
+
+        monkeypatch.setattr(app, "bot", fake_bot)
+        app.GLOBALS[app._BUDGET_KEY] = 0.05
+
+        # Must not raise: the caller still has an HTTP response to send, and
+        # that response is what tells the platform this pod is free again.
+        started = asyncio.get_running_loop().time()
+        await asyncio.wait_for(app._run_bot_with_budget(_args()), timeout=2.0)
+        elapsed = asyncio.get_running_loop().time() - started
+
+        assert saw_cancel.is_set()
+        # Timed, because an absorbing bot makes wait_for return normally rather
+        # than raise: without this the test also passes when the budget is not
+        # enforced at all and the outer wait_for is what stops the bot.
+        assert elapsed < 1.0, f"budget was not enforced (took {elapsed:.2f}s)"
+
+    @sync
+    async def test_propagating_bot_is_stopped_and_returns_cleanly(self, monkeypatch):
+        """The plain-asyncio shape: CancelledError comes back out of bot()."""
+
+        async def fake_bot(args):
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(app, "bot", fake_bot)
+        app.GLOBALS[app._BUDGET_KEY] = 0.05
+
+        started = asyncio.get_running_loop().time()
+        await asyncio.wait_for(app._run_bot_with_budget(_args()), timeout=2.0)
+        elapsed = asyncio.get_running_loop().time() - started
+        assert elapsed < 1.0, f"budget was not enforced (took {elapsed:.2f}s)"
+
+    @sync
+    async def test_bot_within_budget_is_left_alone(self, monkeypatch):
+        finished = asyncio.Event()
+
+        async def fake_bot(args):
+            await asyncio.sleep(0.01)
+            finished.set()
+
+        monkeypatch.setattr(app, "bot", fake_bot)
+        app.GLOBALS[app._BUDGET_KEY] = 5
+
+        await asyncio.wait_for(app._run_bot_with_budget(_args()), timeout=2.0)
+        assert finished.is_set()
+
+    @sync
+    async def test_no_budget_means_no_enforcement(self, monkeypatch):
+        """Absent header → nothing enforced. Never guess a default.
+
+        Only the platform knows the configured value; a hardcoded default would
+        cut sessions short for anyone configured above it (the cap goes up to
+        4h). Without the header the session simply runs on, which is safe
+        because the platform keeps the pod marked occupied.
+        """
+        started = asyncio.Event()
+
+        async def fake_bot(args):
+            started.set()
+            await asyncio.sleep(0.2)
+
+        monkeypatch.setattr(app, "bot", fake_bot)
+        # No _BUDGET_KEY set at all.
+
+        run = asyncio.create_task(app._run_bot_with_budget(_args()))
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        await asyncio.sleep(0.1)
+        assert not run.done(), "bot must not be stopped when no budget was supplied"
+        await asyncio.wait_for(run, timeout=2.0)
+
+
+class TestTeardownIsNotSwallowed:
+    @sync
+    async def test_outer_cancellation_still_propagates(self, monkeypatch):
+        """Only the cancellation we asked for is absorbed.
+
+        If this process is being torn down, the caller must see it rather than
+        us reporting a tidy completion.
+        """
+
+        async def fake_bot(args):
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(app, "bot", fake_bot)
+        app.GLOBALS[app._BUDGET_KEY] = 30  # long enough not to interfere
+
+        run = asyncio.create_task(app._run_bot_with_budget(_args()))
+        await asyncio.sleep(0.05)
+        run.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await run
+
+
+class TestCancellationPrimitive:
+    """The budget is the first caller; a platform stop request would be the next."""
+
+    @sync
+    async def test_session_is_registered_while_running_and_cleared_after(self, monkeypatch):
+        running = asyncio.Event()
+        release = asyncio.Event()
+
+        async def fake_bot(args):
+            running.set()
+            await release.wait()
+
+        monkeypatch.setattr(app, "bot", fake_bot)
+
+        run = asyncio.create_task(app._run_bot_with_budget(_args("sess-registered")))
+        await asyncio.wait_for(running.wait(), timeout=1.0)
+        assert "sess-registered" in app._active_sessions
+
+        release.set()
+        await asyncio.wait_for(run, timeout=2.0)
+        assert "sess-registered" not in app._active_sessions
+
+    @sync
+    async def test_cancel_stops_the_bot_and_records_a_reason(self, monkeypatch):
+        running = asyncio.Event()
+
+        async def fake_bot(args):
+            running.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(app, "bot", fake_bot)
+
+        run = asyncio.create_task(app._run_bot_with_budget(_args("sess-cancel")))
+        await asyncio.wait_for(running.wait(), timeout=1.0)
+
+        handle = app._active_sessions["sess-cancel"]
+        assert handle.cancel("stopped by request") is True
+        assert handle.cancel_reason == "stopped by request"
+
+        await asyncio.wait_for(run, timeout=2.0)
+
+    @sync
+    async def test_cancelling_a_finished_session_is_a_no_op(self, monkeypatch):
+        async def fake_bot(args):
+            return None
+
+        monkeypatch.setattr(app, "bot", fake_bot)
+        task = asyncio.create_task(fake_bot(None))
+        await task
+        handle = app._SessionRun(task)
+        assert handle.cancel("too late") is False
+        assert handle.cancel_reason is None
+
+
+class TestBudgetHeaderParsing:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("7200", 7200.0),
+            ("0.5", 0.5),
+            (None, None),
+            ("", None),
+            ("not-a-number", None),
+            ("0", None),
+            ("-1", None),
+        ],
+    )
+    def test_parse(self, raw, expected):
+        assert app._parse_budget(raw) == expected
+
+
+class TestSmallWebRTCStash:
+    """The budget must survive into a *different* request.
+
+    SmallWebRTC calls run_bot twice: /bot only waits for the WebRTC connection
+    and returns, while the real bot() runs from the /api/offer background task,
+    which never sees these headers. Passing the budget down from the handler
+    would therefore leave that path unbounded — and stopping the /bot wait
+    instead of the bot would hand the pod out while the bot was still running,
+    which is the bug this whole change exists to fix.
+    """
+
+    @sync
+    async def test_handler_stashes_the_budget_for_later_invocations(self, monkeypatch):
+        async def fake_run_bot(args, transport_type=None):
+            return None
+
+        monkeypatch.setattr(app, "run_bot", fake_run_bot)
+
+        await app.handle_bot_request(
+            body={},
+            x_daily_session_id="sess-webrtc",
+            x_pcc_max_session_seconds="1234",
+        )
+        assert app.GLOBALS[app._BUDGET_KEY] == 1234.0
+
+    @sync
+    async def test_absent_header_stashes_none(self, monkeypatch):
+        async def fake_run_bot(args, transport_type=None):
+            return None
+
+        monkeypatch.setattr(app, "run_bot", fake_run_bot)
+
+        await app.handle_bot_request(body={}, x_daily_session_id="sess-none")
+        assert app.GLOBALS[app._BUDGET_KEY] is None

--- a/pipecat-base/tests/test_session_budget.py
+++ b/pipecat-base/tests/test_session_budget.py
@@ -1,10 +1,10 @@
 """PCC-1066: the platform's session budget is enforced inside this process.
 
 Pipecat Cloud caps sessions at ``maxSessionDuration``, but the only thing it can
-do from outside is close its own request to us. On HTTP transports the media
-runs directly between this process and the transport provider, so that close is
-invisible to ``bot()`` and the session carries on — which is how a pod ended up
-running two live pipelines at once. The platform now sends its budget on the
+do from outside is close its own request to us. When a session is started by an
+HTTP request the bot goes on to connect its own media transport, so that close
+is invisible to ``bot()`` and the session carries on — which is how a pod ended
+up running two live pipelines at once. The platform now sends its budget on the
 ``/bot`` request and we stop the bot ourselves.
 
 Two behaviours here are easy to get wrong and are pinned deliberately:
@@ -163,6 +163,34 @@ class TestTeardownIsNotSwallowed:
         run = asyncio.create_task(app._run_bot_with_budget(_args()))
         await asyncio.sleep(0.05)
         run.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await run
+
+    @sync
+    async def test_teardown_during_the_unwind_still_propagates(self, monkeypatch):
+        """The case the budget makes easy to miss.
+
+        ``cancel_reason`` stays set for the rest of the session, so once the
+        budget has fired it can no longer distinguish our own cancellation from
+        a teardown arriving while the bot is still unwinding. Without a separate
+        discriminator this returns normally and the caller never learns the
+        process is going away.
+        """
+
+        async def slow_unwind_bot(args):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                pass  # absorb, like Pipecat's runner
+            await asyncio.sleep(0.5)  # ...then take a while to tear down
+
+        monkeypatch.setattr(app, "bot", slow_unwind_bot)
+        app.GLOBALS[app._BUDGET_KEY] = 0.05
+
+        run = asyncio.create_task(app._run_bot_with_budget(_args()))
+        await asyncio.sleep(0.15)  # budget has fired; bot is mid-unwind
+        run.cancel()
+
         with pytest.raises(asyncio.CancelledError):
             await run
 

--- a/pipecat-base/uv.lock
+++ b/pipecat-base/uv.lock
@@ -984,7 +984,7 @@ wheels = [
 
 [[package]]
 name = "pipecat-base"
-version = "0.1.26"
+version = "0.1.27"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
The base-image half of [PCC-1066](https://linear.app/dailyco/issue/PCC-1066). Pairs with **[sandbox#719](https://github.com/daily-co/pipecat-cloud-sandbox/pull/719)**, which is standalone and can merge in either order.

## The problem

Pipecat Cloud caps sessions at `maxSessionDuration`, but from outside the container all it can do is close its own `/bot` request. On HTTP transports the media runs directly between this process and the transport provider, so that close is invisible to `bot()` and the session carries on. The pod then looks idle and takes another session into the same Python process.

Observed in production (Inderes, 2026-07-29): session `b29a7ff7` hit the 2h cap at 13:06:32, kept serving its broadcast until 13:49, and a second session was placed onto the same process at 13:21. Both died in an OOM at 13:51. The base image logs a matched `Starting bot session` / `Stopping bot session` pair per session — those two sessions each have a `Starting` and no `Stopping`, ever.

sandbox#719 stops the pod being handed out while a bot is live. This PR makes the cap actually stop the bot, which is only possible here.

## What this does

The platform sends `X-PCC-Max-Session-Seconds` on `/bot`; we enforce it around `await bot(args)`.

**No default.** Only the platform knows the configured value, and the limit can be set as high as 4 hours, so a hardcoded default would cut sessions short for anyone above it. An absent header means nothing is enforced, logged once so the inert case is diagnosable from the customer's own logs.

**The budget is stashed in `GLOBALS`, not passed down.** This looks like indirection but is load-bearing: SmallWebRTC calls `run_bot` **twice**. `/bot` only waits for the WebRTC connection and returns (`app.py:138-146`); the real `bot()` runs from the `/api/offer` background task (`app.py:349-355`), which never sees these headers. Passing the budget down from the handler would leave that path unbounded — and bounding the `/bot` wait *instead of* the bot would return the request while the bot was still running, i.e. reintroduce the exact bug this fixes. Same reason `pipecat_session_body` is already stashed.

**Cancellation goes through a small `_SessionRun` handle** rather than a bare `task.cancel()`, so the reason survives and cancellation we asked for is distinguishable from this process being torn down — the latter must still propagate. The budget is its only caller today; a platform "stop this session" request would reuse it without further plumbing. Not building that endpoint here: it would be an unauthenticated control surface on :8080 for a defect nobody has reported.

## Two behaviours pinned deliberately

Both were established by testing against real Pipecat before writing this, and both are easy to get wrong:

1. **A Pipecat bot absorbs the cancellation.** `WorkerRunner.run()` catches `CancelledError` at its `_shutdown_event.wait()` and then runs its *graceful* path — `CancelFrame` through the processors, `cleanup()` on each — in ~19 ms. So nothing is raised, and any "did the budget fire?" logic based on catching an exception silently misses the common case. That is why the reason is checked after the `await` as well as in the `except`.

2. **`run_bot` must return normally either way.** The HTTP response is what tells the platform the pod is free again. If the cancellation escaped instead, the platform would see a dropped connection and classify the session `BOT_DISCONNECTED` (PCC-892) — we would have built a machine that reports every capped session as a bot crash. Verified end-to-end against a real uvicorn server driven with the sidecar's client settings: clean `200` for both the absorbing and propagating bot shapes.

A bot that swallows cancellation and keeps running cannot be stopped by anything in-process — not even an outer `wait_for`. That case is covered by sandbox#719 keeping the pod marked occupied, which is why the two halves are designed together.

## Behaviour change

**Sessions that currently overrun their configured limit will now stop at it.** Scoped:

| Situation | Today | After |
|---|---|---|
| WebSocket transport | ends at the cap | unchanged |
| HTTP, platform-created Daily room | overruns ~5 min until room expiry (`cap + 300`) | ends at the cap |
| HTTP, customer-supplied room or transport | **overruns unboundedly** | ends at the cap |

Only the third row is a real change. Inderes are in it — their ~3h broadcasts against a 2h cap only worked because of the overrun. Workaround is to raise `maxSessionDuration` (max 4h), called out in the changelog.

Docs are corrected in a companion PR: the current wording says the bot "receives a connection error the next time it tries to send or receive data", which has never been true for HTTP transport and is exactly why the session didn't stop.

## Release ordering

**Default the new queue-sidecar before publishing this image.** Picking up a new base image requires a rebuild + redeploy, which stamps the then-current sidecar onto the new revision — so `old sidecar + new base image` is unreachable *only if* the sidecar default has already moved. Getting it wrong is not dangerous (this half is inert without the header), but a customer who rebuilds for the fix would see no change and no signal explaining why.

## Testing

`40 passed`, ruff format + lint clean. New `test_session_budget.py` (17 tests) covers both bot shapes, the within-budget case, absent/malformed/non-positive headers, the teardown-must-propagate rule, the SmallWebRTC stash, and the cancellation primitive.

Mutation-tested: forcing `budget = None` fails both enforcement tests. Worth noting the first pass of that mutation only failed *one* of them — an absorbing bot makes the test's own outer `wait_for` return normally rather than raise, so the test passed for the wrong reason. Both now assert on elapsed time.
