### PR TITLE
ci(pipecat-base): build for amd64 as well as arm64 (PCC-1081)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,11 +68,11 @@ jobs:
         with:
           context: ./pipecat-base
           # Every customer bot is built FROM this image, so an arm64-only base
-          # means an amd64 customer cannot produce a runnable bot at all
-          # (PCC-1081). This runner is arm64, so arm64 is the native leg and
-          # amd64 is emulated; buildx builds them together. Emulation is cheap
-          # here because nothing is compiled from source — the only emulated
-          # work is the apt install, and both platforms build in ~2 minutes.
+          # means an amd64 customer cannot produce a runnable bot at all. This
+          # runner is arm64, so arm64 is the native leg and amd64 is emulated;
+          # buildx builds them together. Emulation is cheap here because nothing
+          # is compiled from source — the only emulated work is the apt install,
+          # and both platforms build in ~2 minutes.
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,13 +63,35 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: ./pipecat-base
-          platforms: linux/arm64
+          # Every customer bot is built FROM this image, so an arm64-only base
+          # means an amd64 customer cannot produce a runnable bot at all
+          # (PCC-1081). The runner is amd64, so this adds the native leg beside
+          # the emulated arm64 one already built here; buildx runs them together.
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # One SBOM per platform, attached to the index. Scanning the index
+          # after the fact would describe only whichever platform resolved.
+          sbom: true
           build-args: |
             VERSION=${{ needs.find-images.outputs.base-version }}
             PYTHON_VERSION=${{ matrix.python-version }}
+
+      - name: Verify the pushed image is multi-arch
+        # Regression guard so a single-arch base cannot land again silently.
+        # Attestation manifests show up as unknown/unknown and are filtered out.
+        if: github.event_name != 'pull_request'
+        run: |
+          ref="dailyco/pipecat-base@${{ steps.build.outputs.digest }}"
+          archs=$(docker buildx imagetools inspect --raw "$ref" \
+            | jq -r '.manifests[].platform | select(.os != "unknown") | "\(.os)/\(.architecture)"' \
+            | sort -u)
+          echo "platforms: $(echo "$archs" | tr '\n' ' ')"
+          for want in linux/amd64 linux/arm64; do
+            echo "$archs" | grep -qx "$want" || { echo "!! missing $want"; exit 1; }
+          done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,8 +69,10 @@ jobs:
           context: ./pipecat-base
           # Every customer bot is built FROM this image, so an arm64-only base
           # means an amd64 customer cannot produce a runnable bot at all
-          # (PCC-1081). The runner is amd64, so this adds the native leg beside
-          # the emulated arm64 one already built here; buildx runs them together.
+          # (PCC-1081). This runner is arm64, so arm64 is the native leg and
+          # amd64 is emulated; buildx builds them together. Emulation is cheap
+          # here because nothing is compiled from source — the only emulated
+          # work is the apt install, and both platforms build in ~2 minutes.
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Every customer bot image is built `FROM dailyco/pipecat-base:<version>`, and this image is published `linux/arm64` only. So an amd64 customer cannot produce a runnable bot **at all** — and that applies to any framework user on amd64 hardware, not only on-prem regions. Part of [PCC-1081](https://linear.app/dailyco/issue/PCC-1081/all-distributed-images-must-be-multi-arch-the-operator-and-pipecat).

Arguably the sharper of the two arm64-only images, since it is customer-facing and affects people who have nothing to do with Pipecat Cloud.

## The change

`platforms: linux/amd64,linux/arm64`, and **this is the cheap direction**. The runner is amd64, so the added leg is the *native* one; the emulated arm64 build is already being paid for today. Buildx builds platforms in parallel, so wall-clock barely moves — the ticket's open question about QEMU cost for a Python image is largely moot, because we are not adding the emulated side.

Worth noting there is no `setup-qemu` step here and never was: `docker/setup-buildx-action` uses the `docker-container` driver, whose BuildKit image ships the QEMU emulators. That is why arm64 already builds.

`sbom: true` switches SBOM generation to BuildKit's per-platform attestations, attached to the index as referring artifacts. Anything scanning the pushed digest afterwards sees the **index** and describes only whichever single platform it resolves.

## Regression guard

A step after the push asserts the index really contains both platforms, so a single-arch base cannot land again silently. It filters `unknown/unknown` entries, which is necessary precisely because SBOM attestations add non-platform manifests to the index. Skipped on pull requests, where nothing is pushed.

## Note on existing tags

Tags published before this stay single-arch — `latest` included, until the next build. Worth deciding whether any published version needs backfilling or whether multi-arch simply starts here.

## Related

`daily-co/pipecat-cloud-operator#244` does the same for the operator image. Both are needed for the ticket's acceptance: an on-prem region running a session on an amd64 node pool.
